### PR TITLE
Bug fix in Tax Query. Changing `AND` operator to `IN`. Closes websharks/wp-kb-articles#32

### DIFF
--- a/wp-kb-articles-pro/includes/classes/sc-list.php
+++ b/wp-kb-articles-pro/includes/classes/sc-list.php
@@ -324,7 +324,7 @@ namespace wp_kb_articles // Root namespace.
 						'terms'            => $this->attr->category,
 						'field'            => 'id',
 						'include_children' => TRUE,
-						'operator'         => 'AND',
+						'operator'         => 'IN',
 					);
 				}
 				if($this->attr->tag)


### PR DESCRIPTION
Bug fix in Tax Query. Changing `AND` operator to `IN`. Closes websharks/wp-kb-articles#32
