### PR TITLE
Closes websharks/wp-kb-articles#62

### DIFF
--- a/wp-kb-articles-pro/includes/classes/toc.php
+++ b/wp-kb-articles-pro/includes/classes/toc.php
@@ -170,7 +170,7 @@ namespace wp_kb_articles // Root namespace.
 
 					$output['toc_markup'] .=  // List item.
 						'<li>'. // This is left open in case of children.
-						'<a href="'.esc_attr('#toc-'.$_heading['crc32b']).'" title="'.esc_attr($_heading['heading']).'">'.
+						'<a href="'.esc_attr('#toc-'.$_heading['crc32b']).'" title="'.esc_attr($_heading['heading']).'" data-toggle="tooltip">'.
 						esc_html($_heading['heading']).
 						'</a>';
 					$_prev_heading = &$_heading; // Reference previous.

--- a/wp-kb-articles-pro/includes/classes/utils-string.php
+++ b/wp-kb-articles-pro/includes/classes/utils-string.php
@@ -878,13 +878,28 @@ namespace wp_kb_articles // Root namespace.
 					return $string; // Not possible.
 
 				$default_args = array(
-					'no_p' => FALSE,
+					'oembed' => FALSE,
+					'no_p'   => FALSE,
 				);
 				$args         = array_merge($default_args, $args);
 				$args         = array_intersect_key($args, $default_args);
 
-				$no_p = (boolean)$args['no_p'];
+				$oembed = (boolean)$args['oembed'];
+				$no_p   = (boolean)$args['no_p'];
 
+				if($oembed && strpos($string, '://') !== FALSE)
+				{
+					$_spcsm           = $this->spcsm_tokens($string, array(), __FUNCTION__);
+					$_oembed_args     = array_merge(wp_embed_defaults(), array('discover' => FALSE));
+					$_spcsm['string'] = preg_replace_callback('/^\s*(https?:\/\/[^\s"]+)\s*$/im', function ($m) use ($_oembed_args)
+					{
+						$oembed = wp_oembed_get($m[1], $_oembed_args);
+						return $oembed ? $oembed : $m[0];
+					}, $_spcsm['string']);
+					$string           = $this->spcsm_restore($_spcsm);
+
+					unset($_spcsm, $_oembed_args); // Housekeeping.
+				}
 				if(!class_exists('\\Parsedown')) // Need Parsedown class here.
 					require_once dirname(dirname(dirname(__FILE__))).'/submodules/parsedown/Parsedown.php';
 
@@ -970,60 +985,176 @@ namespace wp_kb_articles // Root namespace.
 			}
 
 			/**
-			 * Escapes registered WordPress® Shortcodes (i.e. `[[shortcode]]`).
+			 * Shortcode/pre/code/samp/MD tokens.
 			 *
-			 * @param string $string A string value.
+			 * @param string $string Input string to tokenize.
+			 * @param array  $tokenize_only Can be used to limit what is tokenized.
+			 * @param string $marker Optional marker suffix.
 			 *
-			 * @return string String with registered WordPress® Shortcodes escaped.
+			 * @return array Array with: `string`, `tokens`, `marker`.
 			 */
-			public function esc_shortcodes($string)
+			public function spcsm_tokens($string, array $tokenize_only = array(), $marker = '')
 			{
-				return $this->esc_shortcodes_deep((string)$string);
-			}
+				$marker = uniqid('', TRUE).($marker ? '.'.$marker : '');
 
-			/**
-			 * Escapes registered WordPress® Shortcodes (i.e. `[[shortcode]]`) deeply.
-			 *
-			 * @note This is a recursive scan running deeply into multiple dimensions of arrays/objects.
-			 * @note This routine will usually NOT include private, protected or static properties of an object class.
-			 *    However, private/protected properties *will* be included, if the current scope allows access to these private/protected properties.
-			 *    Static properties are NEVER considered by this routine, because static properties are NOT iterated by `foreach()`.
-			 *
-			 * @param mixed $value Any value can be converted into an escaped string.
-			 *    Actually, objects can't, but this recurses into objects.
-			 *
-			 * @return string|array|object Escaped string, array, object.
-			 */
-			public function esc_shortcodes_deep($value)
-			{
-				if(is_array($value) || is_object($value))
+				if(!($string = trim((string)$string))) // Nothing to tokenize.
+					return array('string' => $string, 'tokens' => array(), 'marker' => $marker);
+
+				$spcsm = // Convert string to an array w/ token details.
+					array('string' => $string, 'tokens' => array(), 'marker' => $marker);
+
+				shortcodes: // Target point; `[shortcode][/shortcode]`.
+
+				if($tokenize_only && !in_array('shortcodes', $tokenize_only, TRUE))
+					goto pre; // Not tokenizing these.
+
+				if(empty($GLOBALS['shortcode_tags']) || strpos($spcsm['string'], '[') === FALSE)
+					goto pre; // No `[` shortcodes.
+
+				$spcsm['string'] = preg_replace_callback('/'.get_shortcode_regex().'/s', function ($m) use (&$spcsm)
 				{
-					foreach($value as $_key => &$_value)
-						$_value = $this->esc_shortcodes_deep($_value);
-					unset($_key, $_value);
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
 
-					return $value;
-				}
-				if(empty($GLOBALS['shortcode_tags']) || !is_array($GLOBALS['shortcode_tags']))
-					return (string)$value; // Nothing to do.
+				}, $spcsm['string']); // Shortcodes replaced by tokens.
 
-				return preg_replace_callback('/'.get_shortcode_regex().'/s', array($this, '_esc_shortcodes'), (string)$value);
+				pre: // Target point; HTML `<pre>` tags.
+
+				if($tokenize_only && !in_array('pre', $tokenize_only, TRUE))
+					goto code; // Not tokenizing these.
+
+				if(stripos($spcsm['string'], '<pre') === FALSE)
+					goto code; // Nothing to tokenize here.
+
+				$pre = // HTML `<pre>` tags.
+					'/(?P<tag_open_bracket>\<)'. // Opening `<` bracket.
+					'(?P<tag_open_name>pre)'. // Tag name; e.g. a `pre` tag.
+					'(?P<tag_open_attrs_bracket>\>|\s+[^>]*\>)'. // Attributes & `>`.
+					'(?P<tag_contents>.*?)'. // Tag contents (multiline possible).
+					'(?P<tag_close>\<\/\\2\>)/is'; // e.g. closing `</pre>` tag.
+
+				$spcsm['string'] = preg_replace_callback($pre, function ($m) use (&$spcsm)
+				{
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
+
+				}, $spcsm['string']); // Tags replaced by tokens.
+
+				code: // Target point; HTML `<code>` tags.
+
+				if($tokenize_only && !in_array('code', $tokenize_only, TRUE))
+					goto samp; // Not tokenizing these.
+
+				if(stripos($spcsm['string'], '<code') === FALSE)
+					goto samp; // Nothing to tokenize here.
+
+				$code = // HTML `<code>` tags.
+					'/(?P<tag_open_bracket>\<)'. // Opening `<` bracket.
+					'(?P<tag_open_name>code)'. // Tag name; e.g. a `code` tag.
+					'(?P<tag_open_attrs_bracket>\>|\s+[^>]*\>)'. // Attributes & `>`.
+					'(?P<tag_contents>.*?)'. // Tag contents (multiline possible).
+					'(?P<tag_close>\<\/\\2\>)/is'; // e.g. closing `</code>` tag.
+
+				$spcsm['string'] = preg_replace_callback($code, function ($m) use (&$spcsm)
+				{
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
+
+				}, $spcsm['string']); // Tags replaced by tokens.
+
+				samp: // Target point; HTML `<samp>` tags.
+
+				if($tokenize_only && !in_array('samp', $tokenize_only, TRUE))
+					goto md_fences; // Not tokenizing these.
+
+				if(stripos($spcsm['string'], '<samp') === FALSE)
+					goto md_fences; // Nothing to tokenize here.
+
+				$samp = // HTML `<samp>` tags.
+					'/(?P<tag_open_bracket>\<)'. // Opening `<` bracket.
+					'(?P<tag_open_name>samp)'. // Tag name; e.g. a `samp` tag.
+					'(?P<tag_open_attrs_bracket>\>|\s+[^>]*\>)'. // Attributes & `>`.
+					'(?P<tag_contents>.*?)'. // Tag contents (multiline possible).
+					'(?P<tag_close>\<\/\\2\>)/is'; // e.g. closing `</samp>` tag.
+
+				$spcsm['string'] = preg_replace_callback($samp, function ($m) use (&$spcsm)
+				{
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
+
+				}, $spcsm['string']); // Tags replaced by tokens.
+
+				md_fences: // Target point; Markdown pre/code fences.
+
+				if($tokenize_only && !in_array('md_fences', $tokenize_only, TRUE))
+					goto md_links; // Not tokenizing these.
+
+				if(strpos($spcsm['string'], '~') === FALSE && strpos($spcsm['string'], '`') === FALSE)
+					goto md_links; // Nothing to tokenize here.
+
+				$md_fences = // Markdown pre/code fences.
+					'/(?P<fence_open>~{3,}|`{3,}|`)'. // Opening fence.
+					'(?P<fence_contents>.*?)'. // Contents (multiline possible).
+					'(?P<fence_close>\\1)/is'; // Closing fence; ~~~, ```, `.
+
+				$spcsm['string'] = preg_replace_callback($md_fences, function ($m) use (&$spcsm)
+				{
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
+
+				}, $spcsm['string']); // Fences replaced by tokens.
+
+				md_links: // Target point; [Markdown](links).
+				// This also tokenizes [Markdown]: <link> "definitions".
+				// This routine includes considerations for images also.
+
+				// NOTE: The tokenizer does NOT deal with links that reference definitions, as this is not necessary.
+				//    So, while we DO tokenize <link> "definitions" themselves, the [actual][references] to
+				//    these definitions do not need to be tokenized; i.e. it is not necessary here.
+
+				if($tokenize_only && !in_array('md_links', $tokenize_only, TRUE))
+					goto finale; // Not tokenizing these.
+
+				$spcsm['string'] = preg_replace_callback(array('/^[ ]*(?:\[[^\]]+\])+[ ]*\:[ ]*(?:\<[^>]+\>|\S+)(?:[ ]+.+)?$/m',
+				                                               '/\!?\[(?:(?R)|[^\]]*)\]\([^)]+\)(?:\{[^}]*\})?/'), function ($m) use (&$spcsm)
+				{
+					$spcsm['tokens'][] = $m[0]; // Tokenize.
+					return '%#%spcsm_'.$spcsm['marker'].'|'.(count($spcsm['tokens']) - 1).'%#%'; // Done.
+
+				}, $spcsm['string']); // Shortcodes replaced by tokens.
+
+				finale: // Target point; grand finale (return).
+
+				return $spcsm; // Array w/ string, tokens, and marker.
 			}
 
 			/**
-			 * Callback handler for escaping WordPress® Shortcodes.
+			 * Shortcode/pre/code/samp/MD restoration.
 			 *
-			 * @param array $m An array of regex matches.
+			 * @param array $spcsm `string`, `tokens`, `marker`.
 			 *
-			 * @return string Escaped Shortcode.
+			 * @return string The `string` w/ tokens restored now.
 			 */
-			protected function _esc_shortcodes($m)
+			public function spcsm_restore(array $spcsm)
 			{
-				if(isset($m[1], $m[6]) && $m[1] === '[' && $m[6] === ']')
-					return $m[0]; // Already escaped.
+				if(!isset($spcsm['string']))
+					return ''; // Not possible.
 
-				else // Escape by wrapping with `[` ... `]`.
-					return '['.$m[0].']';
+				if(!($string = trim((string)$spcsm['string'])))
+					return $string; // Nothing to restore.
+
+				$tokens = isset($spcsm['tokens']) ? (array)$spcsm['tokens'] : array();
+				$marker = isset($spcsm['marker']) ? (string)$spcsm['marker'] : '';
+
+				if(!$tokens || !$marker || strpos($string, '%#%') === FALSE)
+					return $string; // Nothing to restore in this case.
+
+				foreach(array_reverse($tokens, TRUE) as $_token => $_value)
+					$string = str_replace('%#%spcsm_'.$marker.'|'.$_token.'%#%', $_value, $string);
+				// Must go in reverse order so nested tokens unfold properly.
+				unset($_token, $_value); // Housekeeping.
+
+				return $string; // Restoration complete.
 			}
 
 			/**

--- a/wp-kb-articles-pro/includes/templates/type-a/site/articles/footer.js.php
+++ b/wp-kb-articles-pro/includes/templates/type-a/site/articles/footer.js.php
@@ -45,6 +45,9 @@ namespace wp_kb_articles;
 
 			$metaAuthorPopularityPopularity.on('click', function(e)
 			{
+				e.preventDefault();
+				e.stopImmediatePropagation();
+
 				var url, $this = $(this);
 
 				if(!$this.hasClass('-active') && !$this.data('castPopularityVote'))

--- a/wp-kb-articles-pro/includes/templates/type-a/site/articles/toc.css
+++ b/wp-kb-articles-pro/includes/templates/type-a/site/articles/toc.css
@@ -2,13 +2,13 @@
   position: relative;
   width: 20%;
   float: right;
-  margin: 0 0 1em 1em;
   box-sizing: border-box;
-  padding: 1em;
+  margin: 0 0 1.5em 1.5em;
+  padding: 1.5em;
   border-radius: .35em;
-  background: #EEEEEE;
-  border: 1px solid #DFDFDF;
-  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.25) inset;
+  background: #F5F5F5;
+  border: 1px solid #E3E3E3;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05) inset;
   font-size: 80%;
 }
 .wp_kb_articles-toc::after {
@@ -33,9 +33,10 @@
 }
 .wp_kb_articles-toc > .-list ul > li {
   font-size: 90%;
-  margin: .5em 0 0 1.5em;
+  margin: .5em 0 0 1em;
 }
 .wp_kb_articles-toc > .-list ul > li::before {
+  content: '\f105';
   font-family: FontAwesome;
   -webkit-font-smoothing: antialiased;
   float: left;
@@ -47,6 +48,7 @@
 .wp_kb_articles-toc > .-list ul > li > a {
   display: block;
   text-decoration: none;
+  border: 0;
   white-space: pre;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -55,15 +57,8 @@
   font-size: 100%;
 }
 .wp_kb_articles-toc > .-list > ul > li::before {
-  content: '\f13d';
   color: #727272;
 }
 .wp_kb_articles-toc > .-list > ul > li:first-child {
   margin-top: 0;
-}
-.wp_kb_articles-toc > .-list > ul > li > ul > li::before {
-  content: '\f0a4';
-}
-.wp_kb_articles-toc > .-list > ul > li > ul > li > ul li::before {
-  content: '\f105';
 }

--- a/wp-kb-articles-pro/includes/templates/type-a/site/articles/toc.scss
+++ b/wp-kb-articles-pro/includes/templates/type-a/site/articles/toc.scss
@@ -32,14 +32,14 @@
 
 	width         : 20%;
 	float         : right;
-	margin        : 0 0 1em 1em;
 	box-sizing    : border-box;
+	margin        : 0 0 1.5em 1.5em;
 
-	padding       : 1em;
+	padding       : 1.5em;
 	border-radius : .35em;
-	background    : #EEEEEE;
-	border        : 1px solid #DFDFDF;
-	box-shadow    : 0 0 0 0 rgba(0, 0, 0, 0.25) inset;
+	background    : #F5F5F5;
+	border        : 1px solid #E3E3E3;
+	box-shadow    : 0 1px 1px rgba(0, 0, 0, 0.05) inset;
 
 	font-size     : 80%;
 
@@ -66,10 +66,11 @@
 		& ul > li
 		{
 			font-size : 90%;
-			margin    : .5em 0 0 1.5em;
+			margin    : .5em 0 0 1em;
 
 			&::before
 			{
+				content                : '\f105';
 				font-family            : FontAwesome;
 				-webkit-font-smoothing : antialiased;
 
@@ -84,6 +85,7 @@
 			{
 				display         : block;
 				text-decoration : none;
+				border          : 0;
 				white-space     : pre;
 				text-overflow   : ellipsis;
 				overflow        : hidden;
@@ -95,26 +97,11 @@
 
 			&::before
 			{
-				content : '\f13d';
-				color   : #727272;
+				color : #727272;
 			}
 			&:first-child
 			{
 				margin-top : 0;
-			}
-		}
-		& > ul > li > ul > li
-		{
-			&::before
-			{
-				content : '\f0a4';
-			}
-		}
-		& > ul > li > ul > li > ul li
-		{
-			&::before
-			{
-				content : '\f105';
 			}
 		}
 	}

--- a/wp-kb-articles-pro/includes/templates/type-s/site/articles/footer.js.php
+++ b/wp-kb-articles-pro/includes/templates/type-s/site/articles/footer.js.php
@@ -45,6 +45,9 @@ namespace wp_kb_articles;
 
 			$metaAuthorPopularityPopularity.on('click', function(e)
 			{
+				e.preventDefault();
+				e.stopImmediatePropagation();
+
 				var url, $this = $(this);
 
 				if(!$this.hasClass('-active') && !$this.data('castPopularityVote'))

--- a/wp-kb-articles-pro/includes/templates/type-s/site/articles/toc.css
+++ b/wp-kb-articles-pro/includes/templates/type-s/site/articles/toc.css
@@ -2,13 +2,13 @@
   position: relative;
   width: 20%;
   float: right;
-  margin: 0 0 1em 1em;
   box-sizing: border-box;
-  padding: 1em;
+  margin: 0 0 1.5em 1.5em;
+  padding: 1.5em;
   border-radius: .35em;
-  background: #EEEEEE;
-  border: 1px solid #DFDFDF;
-  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.25) inset;
+  background: #F5F5F5;
+  border: 1px solid #E3E3E3;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05) inset;
   font-size: 80%;
 }
 .wp_kb_articles-toc::after {
@@ -33,9 +33,10 @@
 }
 .wp_kb_articles-toc > .-list ul > li {
   font-size: 90%;
-  margin: .5em 0 0 1.5em;
+  margin: .5em 0 0 1em;
 }
 .wp_kb_articles-toc > .-list ul > li::before {
+  content: '\f105';
   font-family: FontAwesome;
   -webkit-font-smoothing: antialiased;
   float: left;
@@ -45,21 +46,19 @@
   color: #9B9B9B;
 }
 .wp_kb_articles-toc > .-list ul > li > a {
+  display: block;
   text-decoration: none;
+  border: 0;
+  white-space: pre;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .wp_kb_articles-toc > .-list > ul > li {
   font-size: 100%;
 }
 .wp_kb_articles-toc > .-list > ul > li::before {
-  content: '\f13d';
   color: #727272;
 }
 .wp_kb_articles-toc > .-list > ul > li:first-child {
   margin-top: 0;
-}
-.wp_kb_articles-toc > .-list > ul > li > ul > li::before {
-  content: '\f0a4';
-}
-.wp_kb_articles-toc > .-list > ul > li > ul > li > ul li::before {
-  content: '\f105';
 }

--- a/wp-kb-articles-pro/includes/templates/type-s/site/articles/toc.scss
+++ b/wp-kb-articles-pro/includes/templates/type-s/site/articles/toc.scss
@@ -32,14 +32,14 @@
 
 	width         : 20%;
 	float         : right;
-	margin        : 0 0 1em 1em;
 	box-sizing    : border-box;
+	margin        : 0 0 1.5em 1.5em;
 
-	padding       : 1em;
+	padding       : 1.5em;
 	border-radius : .35em;
-	background    : #EEEEEE;
-	border        : 1px solid #DFDFDF;
-	box-shadow    : 0 0 0 0 rgba(0, 0, 0, 0.25) inset;
+	background    : #F5F5F5;
+	border        : 1px solid #E3E3E3;
+	box-shadow    : 0 1px 1px rgba(0, 0, 0, 0.05) inset;
 
 	font-size     : 80%;
 
@@ -66,10 +66,11 @@
 		& ul > li
 		{
 			font-size : 90%;
-			margin    : .5em 0 0 1.5em;
+			margin    : .5em 0 0 1em;
 
 			&::before
 			{
+				content                : '\f105';
 				font-family            : FontAwesome;
 				-webkit-font-smoothing : antialiased;
 
@@ -82,7 +83,12 @@
 			}
 			& > a
 			{
+				display         : block;
 				text-decoration : none;
+				border          : 0;
+				white-space     : pre;
+				text-overflow   : ellipsis;
+				overflow        : hidden;
 			}
 		}
 		& > ul > li
@@ -91,26 +97,11 @@
 
 			&::before
 			{
-				content : '\f13d';
-				color   : #727272;
+				color : #727272;
 			}
 			&:first-child
 			{
 				margin-top : 0;
-			}
-		}
-		& > ul > li > ul > li
-		{
-			&::before
-			{
-				content : '\f0a4';
-			}
-		}
-		& > ul > li > ul > li > ul li
-		{
-			&::before
-			{
-				content : '\f105';
 			}
 		}
 	}

--- a/wp-kb-articles-pro/plugin.inc.php
+++ b/wp-kb-articles-pro/plugin.inc.php
@@ -480,6 +480,8 @@ namespace wp_kb_articles
 				/*
 				 * Setup all secondary plugin hooks.
 				 */
+				$_this = $this; // Referenced needed by closures.
+
 				add_action('init', array($this, 'register_post_type'), -11, 0);
 				add_action('init', array($this, 'register_rewrite_rules'), -11, 0);
 				add_action('init', array($this, 'actions'), -10, 0);
@@ -498,12 +500,25 @@ namespace wp_kb_articles
 				add_action('wp_print_styles', array($this, 'enqueue_front_styles'), 10, 0);
 
 				add_action('save_post_'.$this->post_type, array($this, 'save_article'), 10, 1);
+
+				add_filter('ezphp_exclude_post', array($this, 'maybe_exclude_article_from_ezphp'), 10, 2);
+
+				add_filter('the_content', array($this, 'maybe_preserve_article_raw_html_content'), -PHP_INT_MAX, 1);
+				add_filter('the_content', array($this, 'maybe_restore_article_raw_html_content'), PHP_INT_MAX - 1, 1);
+
+				add_filter('get_the_excerpt', array($this, 'maybe_preserve_article_raw_html_excerpt'), -PHP_INT_MAX, 1);
+				add_filter('get_the_excerpt', array($this, 'maybe_restore_article_raw_html_excerpt'), PHP_INT_MAX - 1, 1);
+
+				add_filter('the_excerpt', array($this, 'maybe_preserve_article_raw_html_excerpt'), -PHP_INT_MAX, 1);
+				add_filter('the_excerpt', array($this, 'maybe_restore_article_raw_html_excerpt'), PHP_INT_MAX - 1, 1);
+
 				add_filter('the_content', array($this, 'article_toc'), PHP_INT_MAX, 1);
 				add_filter('the_content', array($this, 'article_footer'), PHP_INT_MAX, 1);
 
-				add_shortcode('kb_articles_list', array($this, 'sc_list'));
 				add_filter('author_link', array($this, 'sc_author_link'), 10, 3);
 				add_filter('term_link', array($this, 'sc_term_link'), 10, 3);
+
+				add_shortcode('kb_articles_list', array($this, 'sc_list'));
 				/*
 				 * Setup CRON-related hooks.
 				 */
@@ -1209,6 +1224,102 @@ namespace wp_kb_articles
 			public function save_article($post_id)
 			{
 				$this->utils_post->update_popularity($post_id, 0);
+			}
+
+			/**
+			 * Handle ezPHP exclusions.
+			 *
+			 * @since 150214 Enhancing content/excerpt filters.
+			 *
+			 * @attaches-to `ezphp_exclude_post` filter.
+			 *
+			 * @param boolean  $exclude Excluded?
+			 * @param \WP_Post $post A WP Post object.
+			 *
+			 * @return boolean `TRUE` if post/article is excluded.
+			 */
+			public function maybe_exclude_article_from_ezphp($exclude, \WP_Post $post)
+			{
+				if($post->post_type !== $this->post_type)
+					return $exclude; // Not applicable.
+
+				return $this->utils_github->maybe_exclude_from_ezphp($exclude, $post);
+			}
+
+			/**
+			 * Handle raw HTML content type.
+			 *
+			 * @since 150214 Enhancing content/excerpt filters.
+			 *
+			 * @attaches-to `the_content` filter.
+			 *
+			 * @param string $content The post/article content.
+			 *
+			 * @return string The post/article content.
+			 */
+			public function maybe_preserve_article_raw_html_content($content)
+			{
+				if(!$GLOBALS['post'] || $GLOBALS['post']->post_type !== $this->post_type)
+					return $content; // Not applicable.
+
+				return $this->utils_github->maybe_preserve_raw_html_content($content);
+			}
+
+			/**
+			 * Handle raw HTML content type.
+			 *
+			 * @since 150214 Enhancing content/excerpt filters.
+			 *
+			 * @attaches-to `the_content` filter.
+			 *
+			 * @param string $content The post/article content.
+			 *
+			 * @return string The post/article content.
+			 */
+			public function maybe_restore_article_raw_html_content($content)
+			{
+				if(!$GLOBALS['post'] || $GLOBALS['post']->post_type !== $this->post_type)
+					return $content; // Not applicable.
+
+				return $this->utils_github->maybe_restore_raw_html_content($content);
+			}
+
+			/**
+			 * Handle raw HTML content type.
+			 *
+			 * @since 150214 Enhancing content/excerpt filters.
+			 *
+			 * @attaches-to `get_the_excerpt` and `the_excerpt` filters.
+			 *
+			 * @param string $excerpt The post/article excerpt.
+			 *
+			 * @return string The post/article excerpt.
+			 */
+			public function maybe_preserve_article_raw_html_excerpt($excerpt)
+			{
+				if(!$GLOBALS['post'] || $GLOBALS['post']->post_type !== $this->post_type)
+					return $excerpt; // Not applicable.
+
+				return $this->utils_github->maybe_preserve_raw_html_excerpt($excerpt);
+			}
+
+			/**
+			 * Handle raw HTML content type.
+			 *
+			 * @since 150214 Enhancing content/excerpt filters.
+			 *
+			 * @attaches-to `get_the_excerpt` and `the_excerpt` filters.
+			 *
+			 * @param string $excerpt The post/article excerpt.
+			 *
+			 * @return string The post/article excerpt.
+			 */
+			public function maybe_restore_article_raw_html_excerpt($excerpt)
+			{
+				if(!$GLOBALS['post'] || $GLOBALS['post']->post_type !== $this->post_type)
+					return $excerpt; // Not applicable.
+
+				return $this->utils_github->maybe_restore_raw_html_excerpt($excerpt);
 			}
 
 			/**


### PR DESCRIPTION
 oEmbed + Stripping Shortcodes + More

```
- Adding support for oEmbed in the native Markdown parser.
- Adding raw HTML preservation handlers for the native Markdown parser.
- Adding `*_github_content_type` meta field.
- Enhancing Table of Contents output.
- Enhancing Markdown parser to allow for mixed modes.
- Adding mind map to show MD parsing routines.
- Correcting bug in vote handler when used in a theme other than s2Clean.
- Adding support/exclusions for ezPHP.
```

Closes websharks/wp-kb-articles#62
